### PR TITLE
Tweaked ESLint settings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -228,7 +228,7 @@ module.exports = {
             "warn",
             {
                 ignore: [
-                    1, 0, -1, 2,
+                    1, 0, -1, 2, 200, 201, 400, 401, 500, 9001,
                 ],
                 enforceConst: true,
                 ignoreArrayIndexes: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@html-eslint/eslint-plugin": "^0.19.0",
@@ -18,7 +17,7 @@
     "eslint-plugin-react-hooks": "^4.6.0"
   },
   "scripts": {
-    "lint": "npx eslint .",
-    "lint-fix": "npx eslint --fix --ignore-pattern \"/node_modules/\" --ext .ts,.tsx,.json,.js,.css,.md ."
+    "lint": "npx eslint --ignore-pattern \"node_modules/\" --ext .ts,.tsx,.js .",
+    "lint-fix": "npx eslint --fix --ignore-pattern \"node_modules/\" --ext .ts,.tsx,.js ."
   }
 }

--- a/preppal-be/package.json
+++ b/preppal-be/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "start": "node server.ts",
     "test": "jest --detectOpenHandles",
-    "lint": "npx eslint .",
-    "lint-fix": "npx eslint --fix --ignore-pattern \"/node_modules/\" --ext .ts,.tsx,.json,.js,.css,.md ."
+    "lint": "npx eslint --ignore-pattern \"node_modules/\" --ext .ts,.tsx,.js .",
+    "lint-fix": "npx eslint --fix --ignore-pattern \"node_modules/\" --ext .ts,.tsx,.js ."
   }
 }

--- a/preppal-fe/package.json
+++ b/preppal-fe/package.json
@@ -26,8 +26,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "npx eslint .",
-    "lint-fix": "npx eslint --fix --ignore-pattern \"/node_modules/\" --ext .ts,.tsx,.json,.js,.css,.md ."
+    "lint": "npx eslint --ignore-pattern \"node_modules/\" --ext .ts,.tsx,.js .",
+    "lint-fix": "npx eslint --fix --ignore-pattern \"node_modules/\" --ext .ts,.tsx,.js ."
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
Tweaked ESLint settings to ignore magic numbers that are http status codes, and also ignore css, md, and json files because the parsing doesn't work correctly for those files.