### PR TITLE
api endpoint for own recipes

### DIFF
--- a/preppal-be/routes/recipeApi.ts
+++ b/preppal-be/routes/recipeApi.ts
@@ -7,12 +7,13 @@ const Author = require("../models/user.ts");
 const routerRecipeApi = expressRecipeApi.Router();
 
 /**
- * GET - Get all recipes
+ * GET - Get all public recipes
  */
 routerRecipeApi.get("/", async (req, res) => {
     try {
         const recipes = await Recipe.find();
-        res.status(200).json(recipes);
+        const publicRecipes = recipes?.filter((recipe) => recipe.isPublic) ?? [];
+        res.status(200).json(publicRecipes);
     }
     catch (error) {
         console.error(error.message);
@@ -40,12 +41,13 @@ routerRecipeApi.get("/lookupId/:id", async (req, res) => {
 });
 
 /**
- * GET - Get all recipes with the URL
+ * GET - Get all public recipes by author
  */
 routerRecipeApi.get("/lookupAuthor/:author", async (req, res) => {
     try {
         const recipes = await Recipe.find({ author: req.params.author });
-        res.status(200).json(recipes);
+        const publicRecipes = recipes?.filter((recipe) => recipe.isPublic) ?? [];
+        res.status(200).json(publicRecipes);
     }
     catch (error) {
         console.error(error.message);

--- a/preppal-be/tests/userApi.test.ts
+++ b/preppal-be/tests/userApi.test.ts
@@ -193,6 +193,14 @@ describe("userApi test", function () {
         expect(res.statusCode).toEqual(200);
     });
 
+    it("correct ownRecipes test - get own recipes", async () => {
+        const res = await request(app)
+            .get("/api/users/savedRecipes")
+            .set("x-auth-token", token);
+
+        expect(res.statusCode).toEqual(200);
+    });
+
     it("correct saveRecipe test - save recipeId", async () => {
         const res = await request(app)
             .post("/api/users/saveRecipe")

--- a/preppal-fe/src/pages/collections.tsx
+++ b/preppal-fe/src/pages/collections.tsx
@@ -4,52 +4,28 @@ import RecipeCard from '../components/recipe-card/recipe-card';
 import NavBar from '../components/nav-bar/nav-bar';
 
 const Collections = () => {
-    const [username, setUsername] = React.useState("");
     const [ownRecipes, setOwnRecipes] = React.useState<any[]>([]);
     const [savedRecipes, setSavedRecipes] = React.useState<any[]>([]);
     const [key, setKey] = React.useState("MyRecipes");
 
     React.useEffect(() => {
-        getUser().then(result => setUsername(result));
         getOwnRecipes().then(result => setOwnRecipes(result));
         getSavedRecipes().then(result => setSavedRecipes(result));
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [username]);
+    }, []);
 
-    async function getUser() {
+    async function getOwnRecipes() {
         const token = sessionStorage.getItem("token");
+        let fetchedRecipes: any[] = [];
         try {
             if (token) {
                 const req = {
                     method: "GET",
                     headers: {
-                        "x-auth-token": token
+                        'x-auth-token': token
                     }
                 };
-
-                const res = await fetch("http://localhost:9001/api/auth/", req).then(res => res.json());
-                return res.username;
-            }
-
-            return "";
-
-        } catch (err) {
-
-        }
-    };
-
-    async function getOwnRecipes() {
-        let fetchedRecipes: any[] = [];
-        try {
-            let fetchedRecipes = [];
-            if (username !== "") {
-                const req = {
-                    method: "GET",
-                    headers: {
-                        'Content-Type': 'application/json'
-                    }
-                };
-                fetchedRecipes = await fetch("http://localhost:9001/api/recipes/lookupAuthor/" + username, req).then((res) => res.json());
+                fetchedRecipes = await fetch("http://localhost:9001/api/users/ownRecipes/", req).then((res) => res.json());
             }
             return fetchedRecipes;
         }


### PR DESCRIPTION
add an api endpoint for retrieving own recipes.

The other recipe api endpoints need to change so that they only retrieve public ones instead of all and then sort through the public ones. This is addressed in https://github.com/algorizan/PrepPal/pull/126